### PR TITLE
chore: fix target dir ignore in generated gitignore

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -742,7 +742,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
     // Using the push method with multiple arguments ensures that the entries
     // for all mutually-incompatible VCS in terms of syntax are in sync.
     let mut ignore = IgnoreList::new();
-    ignore.push("/target", "^target/", "target");
+    ignore.push("/target/", "^target/", "target");
     if !opts.bin {
         ignore.push("/Cargo.lock", "^Cargo.lock$", "Cargo.lock");
     }


### PR DESCRIPTION
### What does this PR try to resolve?

The currently generated `/target` spec in a gitignore will match both dirs and files of that name at the root.

This change matches the behavior of the Mercurial spec next to it, by only ignoring dirs of name "target".

### How should we test and review this PR?

Run `cargo new`
